### PR TITLE
np.int was deprecated, np.int64 or np.int32 is needed

### DIFF
--- a/pylipid/func/interactions.py
+++ b/pylipid/func/interactions.py
@@ -100,7 +100,7 @@ class Duration:
         self.contact_low = contact_low
         self.contact_high = contact_high
         self.dt = dt
-        self.pointer = [np.zeros_like(self.contact_high[idx], dtype=np.int)
+        self.pointer = [np.zeros_like(self.contact_high[idx], dtype=np.int64)
                         for idx in range(len(self.contact_high))]
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mdtraj
-numpy
+numpy>=1.2.0
 pandas
 matplotlib>=3.3.3
 networkx


### PR DESCRIPTION
Hi! 

Thanks for this nice tool! 
I just experienced the problem that in numpy np.int is deprecated and one need to specify the precision now using np.int64 or np.int32. I changed this small detail here and hope to make the tool now again compatible with newer numpy versions. 
Best,
Matthias